### PR TITLE
Enhance update-sources.py to update appdata

### DIFF
--- a/update-sources.py
+++ b/update-sources.py
@@ -4,6 +4,8 @@ import json
 import requests
 import sys
 from Crypto.Hash import SHA256
+# https://pypi.org/project/python-dateutil/
+import dateutil.parser
 
 url = 'https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/desktop-releases.json'
 destination = 'sources.json'
@@ -40,3 +42,14 @@ print(json.dumps(content, sort_keys=True, indent=4))
 
 with open(destination, 'w') as f:
     json.dump(content, f, sort_keys=True, indent=4)
+
+
+posts = requests.get('https://forum.obsidian.md/c/announcements/13.json').json()
+
+formatted_version = f"obsidian-release-v{version.replace('.','-')}"
+
+for post in posts['topic_list']['topics']:
+    if post['slug'] == formatted_version:
+        post_date = dateutil.parser.parse(post['created_at'])
+        break
+

--- a/update-sources.py
+++ b/update-sources.py
@@ -87,5 +87,5 @@ update_release_date(appdata, version, publishing_date)
 
 commit_message = f'Updating release version to {version}'
 
-print('Meta has been updated. Now run the following:\n')
+print('Release metadata has been updated. Now run the following commands:\n')
 print(f'git add {appdata} {sources} && git commit -m \"{commit_message}\" && git push\n')


### PR DESCRIPTION
Having the publishing date in `md.obsidian.Obsidian.appdata.xml` updated alongside `sources.json` as part of `update-sources.py` further reduces maintenance burdens. Routine updates should look like this:

```bash
$ ./update-sources.py 
Downloading file from https://github.com/obsidianmd/obsidian-releases/releases/download/v0.9.4/obsidian-0.9.4.tar.gz
Placing the following data inside sources.json:
{
    "sha256": "56474f04fdf5f46b38b50df714d7c5e86fbce3f0e5858574159bf9d0817c4c0f",
    "type": "archive",
    "url": "https://github.com/obsidianmd/obsidian-releases/releases/download/v0.9.4/obsidian-0.9.4.tar.gz"
}
Release metadata has been updated. Now run the following commands:

git add md.obsidian.Obsidian.appdata.xml sources.json && git commit -m "Updating release version to 0.9.4" && git push

```