### PR TITLE
Allow denial of access to '~/.ssh'

### DIFF
--- a/md.obsidian.Obsidian.yml
+++ b/md.obsidian.Obsidian.yml
@@ -18,9 +18,9 @@ finish-args:
   - --filesystem=/mnt
   - --filesystem=/run/media
   - --filesystem=/media
+  - --filesystem=~/.ssh
   - --share=network
   - --share=ipc
-  - --persist=~/.ssh
   - --env=OBSIDIAN_USE_WAYLAND=0
 modules:
   - name: git


### PR DESCRIPTION
This permission is only required when also using the obsidian-git plugin, and is a security risk for everyone else.

[Discussed here](https://www.reddit.com/r/ObsidianMD/comments/sn6nec/why_does_obsidian_need_access_to_ssh/)