### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,8 @@ This flatpak bundles the `gh` binary (the github cli), so use that to login from
 ```
 $ flatpak run --command=gh md.obsidian.Obsidian auth login
 ```
+```
+$ flatpak run --command=gh md.obsidian.Obsidian auth setup-git
+```
+
+


### PR DESCRIPTION
gh auth setup-git is required for the Obsidian git plugin to not prompt for credentials. 

**Before** (asks to provide credentials)
`flatpak run --command=git md.obsidian.Obsidian -C ~/Desktop/repos/obsidian-notes push`
/usr/bin/gh auth git-credential get: line 1: /usr/bin/gh: No such file or directory
Username for 'https://github.com':   

**After** 
flatpak run --command=git md.obsidian.Obsidian -C ~/Desktop/repos/obsidian-notes push
Enumerating objects: 13, done.
Counting objects: 100% (13/13), done.