### PR TITLE
Avoid using absolute paths for gh helper for improving interoperability outside flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ A git repo can also be set up by running the following:
 $ flatpak run --command=gh md.obsidian.Obsidian auth setup-git
 ```
 
-The `gh` binary can resolve to `/app/bin/gh` in `~/.gitconfig` after running `gh auth setup-git` in flatpak, which may be problematic if `gh` is needed outside of flatpak. This can be worked around like so:
+The `gh` binary can resolve to `/app/bin/gh` in `~/.gitconfig` after running `gh auth setup-git` in flatpak, [which may be problematic if `gh` is needed outside of flatpak](https://github.com/cli/cli/issues/7420). This can be worked around like so:
 
 ```
-$ sed -i 's@/app/bin/@/usr/bin/@g' ~/.gitconfig
+$ sed -i 's@/app/bin/@@g' ~/.gitconfig
 ```
 
 ## Middle-click auto-scrolling

--- a/md.obsidian.Obsidian.yml
+++ b/md.obsidian.Obsidian.yml
@@ -28,6 +28,7 @@ finish-args:
   - --share=ipc
   - --persist=~/.ssh
   - --env=SSH_ASKPASS=/app/libexec/openssh/ssh-askpass
+  - --env=GH_PATH=gh
   - --env=OBSIDIAN_USE_WAYLAND=0
   - --env=OBSIDIAN_DISABLE_GPU=0
   - --env=OBSIDIAN_DISABLE_GPU_SANDBOX=0


### PR DESCRIPTION
Fixes https://github.com/flathub/md.obsidian.Obsidian/issues/148