### PR TITLE
Remove XDG_SESSION_TYPE checking for Wayland environment detection

### DIFF
--- a/obsidian.sh
+++ b/obsidian.sh
@@ -19,7 +19,7 @@ add_argument OBSIDIAN_ENABLE_AUTOSCROLL --enable-blink-features=MiddleClickAutos
 
 # Wayland support can be optionally enabled like so:
 # flatpak override --user --socket=wayland md.obsidian.Obsidian
-if [[ "${XDG_SESSION_TYPE:-''}" == "wayland" ]] && [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-"wayland-0"}" ]]; then
+if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-"wayland-0"}" ]]; then
     echo "Debug: Enabling Wayland backend"
     EXTRA_ARGS+=(
         --ozone-platform-hint=auto


### PR DESCRIPTION
Fixes https://github.com/flathub/md.obsidian.Obsidian/issues/224