### PR TITLE
Revert "Suppress segfault output if obsidian crashes (#290)"

### DIFF
--- a/obsidian.sh
+++ b/obsidian.sh
@@ -63,6 +63,4 @@ for i in {0..9}; do
     test -S "$XDG_RUNTIME_DIR"/"discord-ipc-$i" || ln -sf {app/com.discordapp.Discord,"$XDG_RUNTIME_DIR"}/"discord-ipc-$i";
 done
 
-set +o pipefail
-
-zypak-wrapper /app/obsidian $@ ${EXTRA_ARGS[@]} |:
+zypak-wrapper /app/obsidian $@ ${EXTRA_ARGS[@]}


### PR DESCRIPTION
There have been numerous reports of buggy behavior associated with this change.

This reverts commit 659073670252e083bf5b97120ab00d5a8bc3acf2.