### PR TITLE
manifest: enable wayland support

### DIFF
--- a/md.obsidian.Obsidian.yml
+++ b/md.obsidian.Obsidian.yml
@@ -13,7 +13,8 @@ command: obsidian.sh
 tags:
   - proprietary
 finish-args:
-  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --device=dri


### PR DESCRIPTION
Tested options with Flatseal in Sway.

For some reason, XWayland apps do not receive input events properly when in a secondary screen here and now it works so that's evidence it's using Wayland directly.