### PR TITLE
Update md.obsidian.Obsidian.yml

### DIFF
--- a/md.obsidian.Obsidian.yml
+++ b/md.obsidian.Obsidian.yml
@@ -14,6 +14,7 @@ tags:
   - proprietary
 finish-args:
   - --socket=x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --device=dri


### PR DESCRIPTION
Problem: Enabling the Wayland windowing system socket (socket=wayland) in Flatseal for the Obsidian Flatpak causes the window title bar and frame to disappear on KDE Plasma. As a result, the window becomes impossible to move or resize via the GUI.