### PR TITLE
Explicitly set x11 ozone backend by default

### DIFF
--- a/obsidian.sh
+++ b/obsidian.sh
@@ -53,6 +53,10 @@ if [[ -e "${XDG_RUNTIME_DIR}/${WL_DISPLAY}" || -e "/${WL_DISPLAY}" ]]; then
             --disable-gpu-sandbox
         )
     fi
+else
+    EXTRA_ARGS+=(
+        --ozone-platform=x11
+    )
 fi
 
 # The cache files created by Electron and Mesa can become incompatible when there's an upgrade to


### PR DESCRIPTION
Obsidian has upgraded to Electron v39.2.x which enables Wayland by default:

https://obsidian.md/changelog/2026-01-12-desktop-v1.11.4/

Further evaluation is needed before enabling support in the flatpak.

Fixes: https://github.com/flathub/md.obsidian.Obsidian/issues/504 https://github.com/flathub/md.obsidian.Obsidian/issues/505