### PR TITLE
Add note on Wayland fixing scaling/window size retention issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Obsidian has a fairly complete Wayland backend which brings about several improv
 
 * fractional scaling
 * multi-touch gestures such as pinch-zoom
+* retains window sizing and in-app scaling (Settings > Appearance) across restarts
  
 Wayland support can be enabled by setting the environment variable `--socket=wayland` either using [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal), or the command line, like so:
 


### PR DESCRIPTION
Re: #465

I could make this message more detailed perhaps - specifically, does this lack of scaling retention issue apply to native X DE's, or only Wayland DE's emulating X through XWayland? If so, it could be rephrased as

> * for Wayland sessions, retains window sizing ...

or similar

Unfortunately, since I run Pop_OS! 24.04 with the COSMIC DE, it is not trivial for me to get a true X session, given that COSMIC is Wayland only, so I can't check. All I know is that enabling Wayland fixed _my_ issue