### PR TITLE
fix: set wayland default x11 fallback

### DIFF
--- a/md.obsidian.Obsidian.yml
+++ b/md.obsidian.Obsidian.yml
@@ -13,7 +13,8 @@ command: obsidian.sh
 tags:
   - proprietary
 finish-args:
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=ssh-auth
   # Required for accessing keys from a keyring


### PR DESCRIPTION
This change sets Obsidian to run as a native Wayland app, with fallback to x11 if not available. This is more appropriate for the modern landscape.

Resolves https://forum.obsidian.md/t/obsidian-doesnt-launch-in-wayland-mode-on-kde-multimonitor-setup/96386/12