### PR TITLE
Allow Obsidian to launch as wayland by default

### DIFF
--- a/md.obsidian.Obsidian.yml
+++ b/md.obsidian.Obsidian.yml
@@ -13,7 +13,8 @@ command: obsidian.sh
 tags:
   - proprietary
 finish-args:
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=ssh-auth
   # Required for accessing keys from a keyring


### PR DESCRIPTION
This should allow wayland to be used by default without the need for override and it will fallback to x11 if wayland not present